### PR TITLE
feat(ngMocks): add expectRoute and whenRoute shortcuts with colon param matching

### DIFF
--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -1149,7 +1149,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
       return handleResponse;
 
       function handleResponse() {
-        var response = wrapped.response(method, url, data, headers);
+        var response = wrapped.response(method, url, data, headers, wrapped.params(url));
         xhr.$$respHeaders = response[2];
         callback(copy(response[0]), copy(response[1]), xhr.getAllResponseHeaders(),
                  copy(response[3] || ''));
@@ -1230,8 +1230,8 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
    *    headers (Object), and the text for the status (string). The respond method returns the
    *    `requestHandler` object for possible overrides.
    */
-  $httpBackend.when = function(method, url, data, headers) {
-    var definition = new MockHttpExpectation(method, url, data, headers),
+  $httpBackend.when = function(method, url, data, headers, keys) {
+    var definition = new MockHttpExpectation(method, url, data, headers, keys),
         chain = {
           respond: function(status, data, headers, statusText) {
             definition.passThrough = undefined;
@@ -1251,6 +1251,53 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
     definitions.push(definition);
     return chain;
   };
+
+  /**
+   * @ngdoc method
+   * @name $httpBackend#whenRoute
+   * @description
+   * Creates a new backend definition that compares only with the requested route.
+   *
+   * @param {string} method HTTP method.
+   * @param {string} url HTTP url string that supports colon param matching.
+   * @returns {requestHandler} Returns an object with `respond` method that controls how a matched
+   * request is handled. You can save this object for later use and invoke `respond` again in
+   * order to change how a matched request is handled. See #when for more info.
+   */
+  $httpBackend.whenRoute = function(method, url) {
+    var pathObj = parseRoute(url);
+    return $httpBackend.when(method, pathObj.regexp, undefined, undefined, pathObj.keys);
+  };
+
+  function parseRoute(url) {
+    var ret = {
+          regexp: url
+        },
+        keys = ret.keys = [];
+
+    if (!url || !angular.isString(url)) return ret;
+
+    url = url
+      .replace(/([().])/g, '\\$1')
+      .replace(/(\/)?:(\w+)([\?\*])?/g, function(_, slash, key, option) {
+        var optional = option === '?' ? option : null;
+        var star = option === '*' ? option : null;
+        keys.push({ name: key, optional: !!optional });
+        slash = slash || '';
+        return ''
+          + (optional ? '' : slash)
+          + '(?:'
+          + (optional ? slash : '')
+          + (star && '(.+?)' || '([^/]+)')
+          + (optional || '')
+          + ')'
+          + (optional || '');
+      })
+      .replace(/([\/$\*])/g, '\\$1');
+
+    ret.regexp = new RegExp('^' + url, 'i');
+    return ret;
+  }
 
   /**
    * @ngdoc method
@@ -1380,6 +1427,22 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
     return chain;
   };
 
+  /**
+   * @ngdoc method
+   * @name $httpBackend#expectRoute
+   * @description
+   * Creates a new request expectation that compares only with the requested route.
+   *
+   * @param {string} method HTTP method.
+   * @param {string} url HTTP url string that supports colon param matching.
+   * @returns {requestHandler} Returns an object with `respond` method that controls how a matched
+   * request is handled. You can save this object for later use and invoke `respond` again in
+   * order to change how a matched request is handled. See #expect for more info.
+   */
+  $httpBackend.expectRoute = function(method, url) {
+    var pathObj = parseRoute(url)
+    return $httpBackend.expect(method, pathObj.regexp, undefined, undefined, pathObj.keys);
+  };
 
   /**
    * @ngdoc method
@@ -1590,7 +1653,7 @@ function createHttpBackendMock($rootScope, $timeout, $delegate, $browser) {
   }
 }
 
-function MockHttpExpectation(method, url, data, headers) {
+function MockHttpExpectation(method, url, data, headers, keys) {
 
   this.data = data;
   this.headers = headers;
@@ -1628,6 +1691,61 @@ function MockHttpExpectation(method, url, data, headers) {
 
   this.toString = function() {
     return method + ' ' + url;
+  };
+
+  this.params = function(u)
+  {
+    return angular.extend(parseQuery(), pathParams());
+
+    function pathParams() {
+      var keyObj = {};
+      if(!url || !angular.isFunction(url.test) || !keys || keys.length == 0) return keyObj;
+
+      var m = url.exec(u);
+      if(!m) return keyObj;
+
+      for (var i = 1, len = m.length; i < len; ++i) {
+        var key = keys[i - 1];
+        var val = m[i];
+        if (key && val) {
+          keyObj[key.name] = val;
+        }
+      }
+
+      return keyObj;
+    }
+
+    function parseQuery() {
+      var obj = {}, key_value, key,
+          queryStr = u.indexOf('?') > -1
+          ? u.substring(u.indexOf('?') + 1)
+          : "";
+
+      angular.forEach(queryStr.split('&'), function(keyValue) {
+        if (keyValue) {
+          key_value = keyValue.replace(/\+/g,'%20').split('=');
+          key = tryDecodeURIComponent(key_value[0]);
+          if (angular.isDefined(key)) {
+            var val = angular.isDefined(key_value[1]) ? tryDecodeURIComponent(key_value[1]) : true;
+            if (!hasOwnProperty.call(obj, key)) {
+              obj[key] = val;
+            } else if (angular.isArray(obj[key])) {
+              obj[key].push(val);
+            } else {
+              obj[key] = [obj[key],val];
+            }
+          }
+        }
+      });
+      return obj;
+    }
+    function tryDecodeURIComponent(value) {
+      try {
+        return decodeURIComponent(value);
+      } catch (e) {
+        // Ignore any invalid uri component
+      }
+    }
   };
 }
 

--- a/test/ngMock/angular-mocksSpec.js
+++ b/test/ngMock/angular-mocksSpec.js
@@ -1523,18 +1523,22 @@ describe('ngMock', function() {
             hb.flush();
             expect(callback).toHaveBeenCalledOnceWith(200, 'path', '', '');
           });
-          it('should match colon deliminated parameters in ' + routeShortcut + ' ' + method + ' method', function () {
-            hb[routeShortcut](method, '/route/:id/path/:s_id').respond('path');
-            hb(method, '/route/123/path/456', undefined, callback);
-            hb.flush();
-            expect(callback).toHaveBeenCalledOnceWith(200, 'path', '', '');
-          });
-          it('should ignore query param when matching in ' + routeShortcut + ' ' + method + ' method', function () {
-            hb[routeShortcut](method, '/route/:id').respond('path');
-            hb(method, '/route/123?q=str&foo=bar', undefined, callback);
-            hb.flush();
-            expect(callback).toHaveBeenCalledOnceWith(200, 'path', '', '');
-          });
+          it('should match colon deliminated parameters in ' + routeShortcut + ' ' + method + ' method',
+            function () {
+              hb[routeShortcut](method, '/route/:id/path/:s_id').respond('path');
+              hb(method, '/route/123/path/456', undefined, callback);
+              hb.flush();
+              expect(callback).toHaveBeenCalledOnceWith(200, 'path', '', '');
+            }
+          );
+          it('should ignore query param when matching in ' + routeShortcut + ' ' + method + ' method',
+            function () {
+              hb[routeShortcut](method, '/route/:id').respond('path');
+              hb(method, '/route/123?q=str&foo=bar', undefined, callback);
+              hb.flush();
+              expect(callback).toHaveBeenCalledOnceWith(200, 'path', '', '');
+            }
+          );
         });
       });
     });


### PR DESCRIPTION
<- commit message ->
feat(ngMocks): add expectRoute and whenRoute shortcuts with colon param matching

Add whenRoute method to $httpBackend to support matching similar to API backends, which
handles responses based on the query to a particular route. Also includes params in the respond
function to give access to both query params and route colon delimited values.

This is a feature request and is not associated with any open issue
<- end commit message ->

@vokal/web @scottferg 
This is for company review. Before this can be merged into Angular, we'll have to [sign the CLA](https://github.com/vokal/angular.js/blob/master/CONTRIBUTING.md#-signing-the-cla) as a company since the contribution is coming from Vokal. Also, the merge commit message needs to be the same as above per Angular's [contribution requirements](https://github.com/vokal/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines). Let me know if any of the wording should be changed prior to merging this PR.
